### PR TITLE
fix: check if timestamps is set

### DIFF
--- a/src/activity.ts
+++ b/src/activity.ts
@@ -79,6 +79,13 @@ export function getActivity(): Activity | undefined {
 		console.log("No buttons")
 		activity.buttons = undefined
 	}
+	
+	// Timestamps
+
+	if (!activity.timestamps.start && !activity.timestamps.end) {
+		console.log("No timestamps")
+		activity.timestamps = undefined
+	}
 
 	console.log(activity)
 


### PR DESCRIPTION
Discord hates empty objects and will only make it visible client-side. Just wrote a simple check if both start and end are not NaN, undefine `activity.timestamps` if they both are. This can happen if the user doesn't set the timestamps, or not setting it properly (failure during string->number conversion).

Worth noting that this code was blindly written and not tested as I don't have Enmity installed, so make sure you test it before merging 🥴